### PR TITLE
Fix stack overflow for pullable sources of many items

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,17 @@ const pump = inputSource => {
   return outputSource = ( start, outputSink ) => {
     if ( start === 0 ) {
       let talkback;
+      let pulling;
+      let pushReceived;
+
+      const pullWhilePushReceived = () => {
+        pulling = true;
+        do {
+          pushReceived = false;
+          talkback( 1 );
+        } while (pulling && pushReceived);
+        pulling = false;
+      }
 
       inputSource( 0, ( type, data ) => {
         if ( type === 0 ) {
@@ -9,17 +20,23 @@ const pump = inputSource => {
 
           outputSink( 0, ( t, d ) => {
             if ( t === 2 ) {
+              pulling = false;          // exit pull loop
               talkback( 2 );
             }
           });
 
-          talkback( 1 );
+          pullWhilePushReceived();
         }
         else {
           outputSink( type, data );
 
           if ( type === 1 ) {
-            talkback( 1 );
+            if ( pulling ) {
+              pushReceived = true;      // continue pull loop
+            }
+            else {
+              pullWhilePushReceived();  // start pull loop
+            }
           }
         }
       })

--- a/index.spec.js
+++ b/index.spec.js
@@ -3,31 +3,20 @@ const test = require( 'tape' );
 const pump = require( './index' );
 
 test( "pump()", assert => {
-  assert.plan( 2 );
+  assert.plan( 3 );
 
-  const range = function* ( start, end ) {
-    let current = start;
-
-    while ( current <= end ) {
-      yield current;
-      current = current + 1;
-    }
-  }
-
-  const source = ( type, data ) => {
+  const range = ( start, end ) => ( type, data ) => {
     if ( type === 0 ) {
-      const iter = range( 0, 3 );
+      let current = start;
 
       data( 0, ( t, d ) => {
         if ( t === 1 ) {
-          const { done, value } = iter.next();
-
-
-          if ( done ) {
+          if ( current > end ) {
             data( 2 );
           }
           else {
-            data( 1, value );
+            data( 1, current );
+            current = current + 1;
           }
         }
       });
@@ -46,5 +35,13 @@ test( "pump()", assert => {
     }
   }
 
-  pump( source )( 0, sink );
+  pump( range( 0, 3 ) )( 0, sink );
+
+  assert.doesNotThrow(
+    () => {
+      pump( range( 0, 10000) )( 0, () => {} )
+    },
+    null,
+    'The callbag should not throw for pullable sources with many elements'
+  );
 });


### PR DESCRIPTION
A synchronous pullable source pushes data inside the pull call from the sink. When additionally the sink pulls data on every push, the stack grows linearly with the number of items.

This change fixes the problem by pulling items inside a loop as long as an item is pushed back. When the loop exits, it starts anew as soon as another item is pushed.